### PR TITLE
Ken alternative input

### DIFF
--- a/_data/3rdstrike/ken.yml
+++ b/_data/3rdstrike/ken.yml
@@ -26,7 +26,7 @@
 
   command_normal:
     - name: Inazuma Kakato Wari
-      input: Hold MK
+      input: back + MK or Hold MK
       note: ["Overhead"]
 
     - name: Fumikomi Mae Geri


### PR DESCRIPTION
When I first put in the command normals I miswrote this one. It should be back + MK or hold MK, but I wrote MK or hold MK. Quite rightly you took out the first MK, but in fact there are two inputs for that move. Corrected it now!